### PR TITLE
fix: 修复导入证书页面点击取消无反应

### DIFF
--- a/web/src/plugins/ssl-cert/components/CertificateList.vue
+++ b/web/src/plugins/ssl-cert/components/CertificateList.vue
@@ -399,7 +399,10 @@
       class="beauty-dialog"
       destroy-on-close
     >
-      <CertificateUpload @submit="handleCertificateUploaded" />
+      <CertificateUpload 
+        v-if="importDialogVisible"
+        v-model:visible="importDialogVisible"
+        @submit="handleCertificateUploaded" />
     </el-dialog>
 
     <!-- 编辑对话框 -->

--- a/web/src/plugins/ssl-cert/components/CertificateUpload.vue
+++ b/web/src/plugins/ssl-cert/components/CertificateUpload.vue
@@ -209,6 +209,8 @@ interface CertInfo {
 
 const emit = defineEmits<{
   submit: [data: CertInfo]
+  cancel: []
+  'update:visible': [visible: boolean]
 }>()
 
 const activeTab = ref('upload')
@@ -431,6 +433,8 @@ const handleUploadCancel = () => {
   uploadForm.keyFile = null
   if (certFileInput.value) certFileInput.value.value = ''
   if (keyFileInput.value) keyFileInput.value.value = ''
+  emit('update:visible', false)
+  emit('cancel')
 }
 
 // 取消粘贴


### PR DESCRIPTION
## 变更类型
- [√ ] Bug 修复

## 变更描述
修复导入证书页面点击取消无反应

## 相关 Issue
无

## 测试
- [√ ] 已在本地测试

## 截图（如有）
<img width="760" height="682" alt="image" src="https://github.com/user-attachments/assets/19cc92bf-ee24-4ca9-b25f-83e59386b123" />
